### PR TITLE
Fix missing asset metadata on transactions

### DIFF
--- a/backend/app/api/v1/portfolio.py
+++ b/backend/app/api/v1/portfolio.py
@@ -141,7 +141,11 @@ def add_new_transaction(
     portfolio = crud_portfolio.get_portfolio_summary(db, portfolio_id=portfolio_id)
     if not portfolio or portfolio.owner.id != current_user.id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Portfolio not found")
-    return crud_portfolio.add_transaction(db, portfolio_id=portfolio_id, transaction_in=transaction_in)
+
+    try:
+        return crud_portfolio.add_transaction(db, portfolio_id=portfolio_id, transaction_in=transaction_in)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 @router.get("/{portfolio_id}/transactions", response_model=List[Transaction])
 def get_portfolio_transactions(

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -2,6 +2,7 @@
 Pydantic modeller for Transaction verileri.
 """
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -22,8 +23,8 @@ class TransactionCreate(TransactionBase):
     """Yeni işlem oluştururken kullanılan alanlar."""
 
     symbol: str
-    asset_name: str
-    asset_type: AssetType
+    asset_name: Optional[str] = None
+    asset_type: Optional[AssetType] = None
 
 
 class Transaction(TransactionBase):


### PR DESCRIPTION
## Summary
- require asset metadata when recording a new symbol transaction to avoid placeholder assets
- reuse provided metadata to keep assets in sync when repeated transactions arrive

## Testing
- cd backend && pytest -q
- Manual FastAPI TestClient against postgresql://portfolio_user:admin@localhost/portfolio_db